### PR TITLE
adding python binder example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "day2/Model-Evaluation-Activity"]
 	path = day2/Model-Evaluation-Activity
 	url = https://github.com/mmaslej/Model-Evaluation-Activity.git
+[submodule "day1/example-python-repo"]
+	path = day1/example-python-repo
+	url = https://github.com/krembilneuroinformatics/example-python-repo.git


### PR DESCRIPTION
python binder example is a submodule references to another repo in the krembilneuroinformatics space